### PR TITLE
issue #205 flexible source file extension

### DIFF
--- a/compiler/rxcpmain.c
+++ b/compiler/rxcpmain.c
@@ -62,6 +62,12 @@ static void error_and_exit(int rc, char* message) {
     exit(rc);
 }
 
+const char *get_filename_ext(const char *filename) {
+    const char *dot = strrchr(filename, '.');
+    if(!dot || dot == filename) return "";
+    return dot + 1;
+}
+
 int main(int argc, char *argv[]) {
 
     FILE *fp, *traceFile = 0, *outFile = 0;
@@ -141,7 +147,13 @@ int main(int argc, char *argv[]) {
     if (!output_file_name) output_file_name = file_name;
 
     /* Open input file */
-    fp = openfile(file_name, "rexx", location, "r");
+    char* filename_extension = get_filename_ext(file_name);
+    if (filename_extension == "")
+      { fp = openfile(file_name,"rexx", location, "r");
+      }
+    else {
+      fp = openfile(file_name,"", location, "r");
+    }
     if (fp == NULL) {
         fprintf(stderr, "Can't open input file: %s\n", file_name);
         exit(-1);

--- a/history.txt
+++ b/history.txt
@@ -1,5 +1,5 @@
 CREXX History / Change Log
-
+I0205 - Flexible source file extension
 I0265 - Fixed Segfault when there is a duplicate procedure definition
 F0031 - VM Performance Optimisations
 F0035 - (Almost) complete REXX/RXAS BIF library

--- a/platform/platform.c
+++ b/platform/platform.c
@@ -47,7 +47,12 @@ FILE *openfile(char *name, char *type, char *dir, char *mode) {
     len = strlen(name) + strlen(type) + strlen(dir) + 3;
 
     file_name = malloc(len);
-    snprintf(file_name, len, "%s/%s.%s", dir, name, type);
+    if (type=="") {
+      snprintf(file_name, len, "%s/%s", dir, name, type);
+    }
+    else {
+      snprintf(file_name, len, "%s/%s.%s", dir, name, type);
+    }
 
     stream = fopen(file_name, mode);
 


### PR DESCRIPTION
contains the possibility to specify a file extension for the rxc processor. Will mostly be used for tab completion to .rexx, which is the default, but keeps possibility to choose other extensions.