### PR TITLE
Feature/f0052

### DIFF
--- a/assembler/rxasassm.h
+++ b/assembler/rxasassm.h
@@ -4,7 +4,7 @@
 #ifndef CREXX_RXASASSM_H
 #define CREXX_RXASASSM_H
 
-#define rxversion "crexx-f0051"
+#define rxversion "crexx-f0052"
 
 #include "rxas.h"
 #include "rxasgrmr.h"

--- a/compiler/rxcpemit.c
+++ b/compiler/rxcpemit.c
@@ -2056,7 +2056,7 @@ static walker_result emit_walker(walker_direction direction,
                 i = node->additional_registers + 1; /* First one is the number of arguments */
                 while (n) {
                     if (n->cleanup) output_concat(node->output, n->cleanup);
-                    if (n->register_num != i) {
+                    if (n->register_type != 'r' ||  n->register_num != i) {
                         /* We need to swap registers */
                         /* I have reversed arguments just for readability */
                         temp1 = mprintf("   swap %c%d,r%d\n",

--- a/compiler/rxcpfunc.c
+++ b/compiler/rxcpfunc.c
@@ -403,10 +403,10 @@ char* rxpa_getstring(rxpa_attribute_value attributeValue)  /* Get a string from 
 void rxpa_setstring(rxpa_attribute_value attributeValue, char* string)  /* Set a string in an attribute value */
     { disablerFunction("rxpa_setstring"); }
 
-void rxpa_setint(rxpa_attribute_value attributeValue, int value)  /* Set an integer in an attribute value */
+void rxpa_setint(rxpa_attribute_value attributeValue, rxinteger value)  /* Set an integer in an attribute value */
     { disablerFunction("rxpa_setint"); }
 
-int rxpa_getint(rxpa_attribute_value attributeValue)  /* Get an integer from an attribute value */
+rxinteger rxpa_getint(rxpa_attribute_value attributeValue)  /* Get an integer from an attribute value */
     { disablerFunction("rxpa_getint"); return 0; }
 
 void rxpa_setfloat(rxpa_attribute_value attributeValue, double value)  /* Set a float in an attribute value */
@@ -414,6 +414,13 @@ void rxpa_setfloat(rxpa_attribute_value attributeValue, double value)  /* Set a 
 
 double rxpa_getfloat(rxpa_attribute_value attributeValue)  /* Get a float from an attribute value */
     { disablerFunction("rxpa_getfloat"); return 0.0; }
+
+// Exit Function Management
+void rxpa_setsayexit(say_exit_func sayExitFunc)  /* Set Say exit function */
+    { disablerFunction("rxpa_setsayexit"); }
+
+void rxpa_resetsayexit()  /* Reset Say exit function */
+    { disablerFunction("rxpa_resetsayexit"); }
 
 // RXPA Add Function Implementation
 // This is the callback function for loadPluginFileForFunctions() when the plugin adds functions,
@@ -450,6 +457,8 @@ static void loadPluginFileForFunctions(Context *context, char* file_name, char* 
     rxpa_context.getint = rxpa_getint;
     rxpa_context.setfloat = rxpa_setfloat;
     rxpa_context.getfloat = rxpa_getfloat;
+    rxpa_context.setsayexit = rxpa_setsayexit;
+    rxpa_context.resetsayexit = rxpa_resetsayexit;
 
     if (context->debug_mode) printf("Importing Procedures - Reading CREXX Plugin file %s for possible procedure imports\n", file_name);
 

--- a/compiler/rxcpmain.h
+++ b/compiler/rxcpmain.h
@@ -4,7 +4,7 @@
 #ifndef CREXX_RXCPMAIN_H
 #define CREXX_RXCPMAIN_H
 
-#define rxversion "crexx-f0051"
+#define rxversion "crexx-f0052"
 
 #include <stdio.h>
 #include "platform.h"

--- a/cpacker/rxcpack.c
+++ b/cpacker/rxcpack.c
@@ -12,7 +12,7 @@
 #include <string.h>
 #include <ctype.h>
 
-#define rxversion "crexx-f0051"
+#define rxversion "crexx-f0052"
 
 #define NAME_BUFFER_SIZE 256
 #define GLOBAL_SYMBOL "rx__pg"

--- a/disassembler/rxdadism.h
+++ b/disassembler/rxdadism.h
@@ -4,7 +4,7 @@
 #include "rxas.h"
 #include "rxbin.h"
 
-#define rxversion "crexx-f0051"
+#define rxversion "crexx-f0052"
 
 /* Disassembler */
 void disassemble(bin_space *pgm, module_file *module, FILE *stream, int print_all_constant_pool);

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # CREXX
 
-_Release Documentation - crexx-f0051 - Sept 2022_
+_Release Documentation - crexx-f0052 - Sept 2022_
 
 ## REXX Language Implementation Architecture
 
@@ -40,7 +40,7 @@ The documentation is stored in the code repository/branch under the [/doc](https
 
 # Current Component User Documentation
 
-crexx-f0051
+crexx-f0052
 
 ## Running a REXX program
 

--- a/history.txt
+++ b/history.txt
@@ -1,7 +1,11 @@
 CREXX History / Change Log
 
-F0052 - RXPA (Plugin Architecture)
-        Fixes and enhancements
+F0052 - Fixes and enhancements
+        RXPA - Added an "exit" to trap say instruction output
+        Compiler - Fix Register swap back after a function call with global register
+        Interpreter - Printing floats, changed max precision to 15 from 6 digits
+        Compiler - Fix segfault with a missing argument before an ellipsis
+        Compiler - Fix segfault when exposing an unknown variable
 F0051 - RXPA (Plugin Architecture)
            Fix - rxc optimised constant arguments to pass by reference incorrectly setting the argument signature
 I0350 - Add - EXIT (and _exit function in _rxsysb file _rxsystem.rexx)

--- a/history.txt
+++ b/history.txt
@@ -1,6 +1,8 @@
 CREXX History / Change Log
 
-F0051 - CREXX/C
+F0052 - RXPA (Plugin Architecture)
+        Fixes and enhancements
+F0051 - RXPA (Plugin Architecture)
            Fix - rxc optimised constant arguments to pass by reference incorrectly setting the argument signature
 I0350 - Add - EXIT (and _exit function in _rxsysb file _rxsystem.rexx)
         Fix - ADDRESS for a not found command freezes (on linux and osx)

--- a/interpreter/CMakeLists.txt
+++ b/interpreter/CMakeLists.txt
@@ -9,7 +9,7 @@ set(CMAKE_C_FLAGS_RELEASE "-O3 -DNDEBUG") # Can do more I am sure but this is ab
 # Bare Interpreter
 # Threaded Version
 add_executable(rxvm rxvmmain.c rxvmintp.h rxvmintp.c rxvmload.c ../avl_tree/rxastree.h
-        ../utf8/utf.h ../machine/rxbin.h rxspawn.c
+        ../utf8/utf.h ../machine/rxbin.h rxspawn.c exitfunc.c
         rxpafuncs.c)
 set_property(TARGET rxvm PROPERTY INTERPROCEDURAL_OPTIMIZATION_RELEASE TRUE)
 set_property(TARGET rxvm PROPERTY INTERPROCEDURAL_OPTIMIZATION_DEBUG FALSE)
@@ -21,7 +21,7 @@ target_include_directories(rxvm PRIVATE . ${CMAKE_BINARY_DIR}/machine
 
 # Bytecode Version
 add_executable(rxbvm rxvmmain.c rxvmintp.h rxvmintp.c rxvmload.c ../avl_tree/rxastree.h
-        ../utf8/utf.h ../machine/rxbin.h rxspawn.c
+        ../utf8/utf.h ../machine/rxbin.h rxspawn.c exitfunc.c
         rxpafuncs.c)
 add_dependencies(rxbvm machine avl_tree rxpa platform)
 target_link_libraries(rxbvm machine avl_tree rxpa platform m)
@@ -44,7 +44,7 @@ add_custom_target(packed_library ALL DEPENDS library.c)
 
 # Threaded Version
 add_executable(rxvme rxvmmain.c rxvmintp.h rxvmintp.c rxvmload.c ../avl_tree/rxastree.h
-        ../utf8/utf.h ../machine/rxbin.h rxspawn.c ${CMAKE_CURRENT_BINARY_DIR}/library.c
+        ../utf8/utf.h ../machine/rxbin.h rxspawn.c exitfunc.c ${CMAKE_CURRENT_BINARY_DIR}/library.c
         rxpafuncs.c)
 target_compile_definitions(rxvme PRIVATE LINK_CREXX_LIB=1)
 set_property(TARGET rxvme PROPERTY INTERPROCEDURAL_OPTIMIZATION_RELEASE TRUE)
@@ -56,7 +56,7 @@ target_include_directories(rxvme PRIVATE . ${CMAKE_BINARY_DIR}/machine
         ../assembler ../machine ${CMAKE_SOURCE_DIR}/rxpa ../platform ../avl_tree ../utf8)
 
 add_executable(rxbvme rxvmmain.c rxvmintp.h rxvmintp.c rxvmload.c ../avl_tree/rxastree.h
-        ../utf8/utf.h ../machine/rxbin.h rxspawn.c ${CMAKE_CURRENT_BINARY_DIR}/library.c
+        ../utf8/utf.h ../machine/rxbin.h rxspawn.c exitfunc.c ${CMAKE_CURRENT_BINARY_DIR}/library.c
         rxpafuncs.c)
 add_dependencies(rxbvme machine avl_tree rxpa platform packed_library)
 target_link_libraries(rxbvme machine avl_tree rxpa platform m)
@@ -69,7 +69,7 @@ target_compile_definitions(rxbvme PRIVATE NTHREADED=1 LINK_CREXX_LIB=1)
 
 # Threaded Version
 add_library(rxvml STATIC rxvmlib.c rxvmintp.h rxvmintp.c rxvmload.c ../avl_tree/rxastree.h
-        ../utf8/utf.h ../machine/rxbin.h rxspawn.c
+        ../utf8/utf.h ../machine/rxbin.h rxspawn.c exitfunc.c
         rxpafuncs.c)
 set_property(TARGET rxvml PROPERTY INTERPROCEDURAL_OPTIMIZATION_RELEASE TRUE)
 set_property(TARGET rxvml PROPERTY INTERPROCEDURAL_OPTIMIZATION_DEBUG FALSE)
@@ -80,7 +80,7 @@ target_include_directories(rxvml PRIVATE . ${CMAKE_BINARY_DIR}/machine
 
 # Bytecode Version
 add_library(rxbvml STATIC rxvmlib.c rxvmintp.h rxvmintp.c rxvmload.c ../avl_tree/rxastree.h
-        ../utf8/utf.h ../machine/rxbin.h rxspawn.c
+        ../utf8/utf.h ../machine/rxbin.h rxspawn.c exitfunc.c
         rxpafuncs.c)
 add_dependencies(rxbvml machine avl_tree rxpa platform)
 target_include_directories(rxbvml PRIVATE . ${CMAKE_BINARY_DIR}/machine

--- a/interpreter/exitfunc.c
+++ b/interpreter/exitfunc.c
@@ -1,0 +1,52 @@
+/* Exit Function Support */
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdarg.h>
+#include "rxpa.h"
+
+// Function Prototypes
+void say_exit_default(char* message); // Default say exit function
+
+// Global Variables
+say_exit_func say_exit = say_exit_default;
+
+/* Default Say Exit Function - prints to stdout */
+void say_exit_default(char* message) {
+    /* Print the message to stdout without a newline or any formatting */
+    printf("%s", message);
+}
+
+/* Set the say exit function */
+void rxpa_setsayexit(say_exit_func sayExitFunc) {
+    say_exit = sayExitFunc;
+}
+
+/* Reset the say exit function */
+void rxpa_resetsayexit() {
+    say_exit = say_exit_default;
+}
+
+/* printf replacement - prints to the say exit function (or stdout) */
+#define FIXED_BUFFER_SIZE 100 // Fixed buffer size for small messages
+void mprintf(const char* format, ...) {
+    char *buffer;
+    char fixed_buffer[FIXED_BUFFER_SIZE];
+    size_t needed_len;
+    va_list argptr;
+
+    va_start(argptr, format);
+    needed_len = vsnprintf(fixed_buffer, FIXED_BUFFER_SIZE, format, argptr) + 1;
+    va_end(argptr);
+    if (needed_len > FIXED_BUFFER_SIZE) {
+        /* Buffer not big enough - do it again with a dynamic buffer now we know the size needed */
+        buffer = malloc(needed_len);
+        va_start(argptr, format);
+        vsnprintf(buffer, needed_len, format, argptr);
+        va_end(argptr);
+        say_exit(buffer);
+        free(buffer);
+    }
+    else {
+        say_exit(fixed_buffer);
+    }
+}

--- a/interpreter/rxpafuncs.c
+++ b/interpreter/rxpafuncs.c
@@ -93,15 +93,15 @@ void rxpa_setstring(rxpa_attribute_value attributeValue, char* string){
 }
 
 /* Set an integer in an attribute value */
-void rxpa_setint(rxpa_attribute_value attributeValue, int int_value) {
+void rxpa_setint(rxpa_attribute_value attributeValue, rxinteger int_value) {
     value* val = (value*)attributeValue;
     if (val) set_int(val, int_value);
 }
 
 /* Get an integer from an attribute value */
-int rxpa_getint(rxpa_attribute_value attributeValue) {
+rxinteger rxpa_getint(rxpa_attribute_value attributeValue) {
     value* val = (value*)attributeValue;
-    if (val) return (int)val->int_value;
+    if (val) return val->int_value;
     else return 0;
 }
 

--- a/interpreter/rxvmintp.c
+++ b/interpreter/rxvmintp.c
@@ -1173,7 +1173,7 @@ START_OF_INSTRUCTIONS
  *  -----------------------------------------------------------------------------------
  */
         START_INSTRUCTION(RET_FLOAT)
-            DEBUG("TRACE - RET %g\n", op1F);
+            DEBUG("TRACE - RET %.15g\n", op1F);
             {
                 /* Where we return to */
                 next_pc = current_frame->return_pc;
@@ -1983,7 +1983,7 @@ START_OF_INSTRUCTIONS
  *  -----------------------------------------------------------------------------------
  */
         START_INSTRUCTION(FEQ_REG_REG_FLOAT) CALC_DISPATCH(3)
-            DEBUG("TRACE - FEQ R%d,R%d,%g\n", (int)REG_IDX(1), (int)REG_IDX(2), op3F);
+            DEBUG("TRACE - FEQ R%d,R%d,%.15g\n", (int)REG_IDX(1), (int)REG_IDX(2), op3F);
             REG_RETURN_INT(op2RF == op3F)
             DISPATCH
 
@@ -2001,7 +2001,7 @@ START_OF_INSTRUCTIONS
  *  -----------------------------------------------------------------------------------
  */
         START_INSTRUCTION(FNE_REG_REG_FLOAT) CALC_DISPATCH(3)
-            DEBUG("TRACE - FNE R%d,R%d,%g\n", (int)REG_IDX(1), (int)REG_IDX(2), op3F);
+            DEBUG("TRACE - FNE R%d,R%d,%.15g\n", (int)REG_IDX(1), (int)REG_IDX(2), op3F);
             REG_RETURN_INT(op2RF != op3F)
             DISPATCH
 
@@ -2020,7 +2020,7 @@ START_OF_INSTRUCTIONS
  *  -----------------------------------------------------------------------------------
  */
         START_INSTRUCTION(FGT_REG_REG_FLOAT) CALC_DISPATCH(3)
-            DEBUG("TRACE - FGT R%d,R%d,%g\n", (int)REG_IDX(1), (int)REG_IDX(2), op3F);
+            DEBUG("TRACE - FGT R%d,R%d,%.15g\n", (int)REG_IDX(1), (int)REG_IDX(2), op3F);
             REG_RETURN_INT(op2RF > op3F)
             DISPATCH
 
@@ -2029,7 +2029,7 @@ START_OF_INSTRUCTIONS
  *  -----------------------------------------------------------------------------------
  */
         START_INSTRUCTION(FGT_REG_FLOAT_REG) CALC_DISPATCH(3)
-            DEBUG("TRACE - FGT R%d,%g,R%d\n", (int)REG_IDX(1), op2F, (int)REG_IDX(3));
+            DEBUG("TRACE - FGT R%d,%.15g,R%d\n", (int)REG_IDX(1), op2F, (int)REG_IDX(3));
             REG_RETURN_INT(op2F > op3RF)
             DISPATCH
 
@@ -2047,7 +2047,7 @@ START_OF_INSTRUCTIONS
  *  -----------------------------------------------------------------------------------
  */
         START_INSTRUCTION(FLT_REG_REG_FLOAT) CALC_DISPATCH(3)
-            DEBUG("TRACE - FLT R%d,R%d,%g\n", (int)REG_IDX(1), (int)REG_IDX(2), op3F);
+            DEBUG("TRACE - FLT R%d,R%d,%.15g\n", (int)REG_IDX(1), (int)REG_IDX(2), op3F);
             REG_RETURN_INT(op2RF < op3F)
             DISPATCH
 
@@ -2056,7 +2056,7 @@ START_OF_INSTRUCTIONS
  *  -----------------------------------------------------------------------------------
  */
         START_INSTRUCTION(FLT_REG_FLOAT_REG) CALC_DISPATCH(3)
-            DEBUG("TRACE - FLT R%d,%g,R%d\n", (int)REG_IDX(1), op2F, (int)REG_IDX(3));
+            DEBUG("TRACE - FLT R%d,%.15g,R%d\n", (int)REG_IDX(1), op2F, (int)REG_IDX(3));
             REG_RETURN_INT(op2F < op3RF)
             DISPATCH
 
@@ -2074,7 +2074,7 @@ START_OF_INSTRUCTIONS
  *  -----------------------------------------------------------------------------------
  */
         START_INSTRUCTION(FGTE_REG_REG_FLOAT) CALC_DISPATCH(3)
-            DEBUG("TRACE - FGTE R%d,R%d,%g\n", (int)REG_IDX(1), (int)REG_IDX(2), op3F);
+            DEBUG("TRACE - FGTE R%d,R%d,%.15g\n", (int)REG_IDX(1), (int)REG_IDX(2), op3F);
             REG_RETURN_INT(op2RF >= op3F)
             DISPATCH
 
@@ -2083,7 +2083,7 @@ START_OF_INSTRUCTIONS
  *  -----------------------------------------------------------------------------------
  */
         START_INSTRUCTION(FGTE_REG_FLOAT_REG) CALC_DISPATCH(3)
-            DEBUG("TRACE - FGTE R%d,%g,R%d\n", (int)REG_IDX(1), op2F, (int)REG_IDX(3));
+            DEBUG("TRACE - FGTE R%d,%.15g,R%d\n", (int)REG_IDX(1), op2F, (int)REG_IDX(3));
             REG_RETURN_INT(op2F >= op3RF)
             DISPATCH
 
@@ -2101,7 +2101,7 @@ START_OF_INSTRUCTIONS
  *  -----------------------------------------------------------------------------------
  */
         START_INSTRUCTION(FLTE_REG_REG_FLOAT) CALC_DISPATCH(3)
-            DEBUG("TRACE - FLTE R%d,R%d,%g\n", (int)REG_IDX(1), (int)REG_IDX(2), op3F);
+            DEBUG("TRACE - FLTE R%d,R%d,%.15g\n", (int)REG_IDX(1), (int)REG_IDX(2), op3F);
             REG_RETURN_INT(op2RF <= op3F)
             DISPATCH
 /* ------------------------------------------------------------------------------------
@@ -2109,7 +2109,7 @@ START_OF_INSTRUCTIONS
  *  -----------------------------------------------------------------------------------
  */
         START_INSTRUCTION(FLTE_REG_FLOAT_REG) CALC_DISPATCH(3)
-            DEBUG("TRACE - FLTE R%d,%g,R%d\n", (int)REG_IDX(1), op2F, (int)REG_IDX(3));
+            DEBUG("TRACE - FLTE R%d,%.15g,R%d\n", (int)REG_IDX(1), op2F, (int)REG_IDX(3));
             REG_RETURN_INT(op2F <= op3RF)
             DISPATCH
 /* ------------------------------------------------------------------------------------
@@ -2597,8 +2597,8 @@ START_OF_INSTRUCTIONS
  *  -----------------------------------------------------------------------------------
  */
         START_INSTRUCTION(SAY_FLOAT) CALC_DISPATCH(1)
-            DEBUG("TRACE - SAY %g\n", op1F);
-            mprintf("%g\n", op1F);
+            DEBUG("TRACE - SAY %.15g\n", op1F);
+            mprintf("%.15g\n", op1F);
             DISPATCH
 
 /* ------------------------------------------------------------------------------------
@@ -2606,7 +2606,7 @@ START_OF_INSTRUCTIONS
  *  -----------------------------------------------------------------------------------
  */
         START_INSTRUCTION(LOAD_REG_FLOAT) CALC_DISPATCH(2)
-            DEBUG("TRACE - LOAD R%d,%g\n",(int)REG_IDX(1),op2F);
+            DEBUG("TRACE - LOAD R%d,%.15g\n",(int)REG_IDX(1),op2F);
             REG_RETURN_FLOAT(op2F)
             DISPATCH
 
@@ -2652,7 +2652,7 @@ START_OF_INSTRUCTIONS
  *  -----------------------------------------------------------------------------------
  */
         START_INSTRUCTION(FADD_REG_REG_FLOAT) CALC_DISPATCH(3)
-            DEBUG("TRACE - FADD R%d,R%d,%g\n", (int)REG_IDX(1), (int)REG_IDX(2), op3F);
+            DEBUG("TRACE - FADD R%d,R%d,%.15g\n", (int)REG_IDX(1), (int)REG_IDX(2), op3F);
             REG_RETURN_FLOAT(op2RF + op3F)
             DISPATCH
 
@@ -2661,7 +2661,7 @@ START_OF_INSTRUCTIONS
  *  -----------------------------------------------------------------------------------
  */
         START_INSTRUCTION(FSUB_REG_REG_FLOAT) CALC_DISPATCH(3)
-            DEBUG("TRACE - FSUB R%d,R%d,%g\n", (int)REG_IDX(1), (int)REG_IDX(2), op3F);
+            DEBUG("TRACE - FSUB R%d,R%d,%.15g\n", (int)REG_IDX(1), (int)REG_IDX(2), op3F);
             REG_RETURN_FLOAT(op2RF - op3F)
             DISPATCH
 
@@ -2670,7 +2670,7 @@ START_OF_INSTRUCTIONS
  *  -----------------------------------------------------------------------------------
  */
         START_INSTRUCTION(FDIV_REG_REG_FLOAT) CALC_DISPATCH(3)
-            DEBUG("TRACE - FDIV R%d,R%d,%g\n", (int)REG_IDX(1), (int)REG_IDX(2), op3F);
+            DEBUG("TRACE - FDIV R%d,R%d,%.15g\n", (int)REG_IDX(1), (int)REG_IDX(2), op3F);
             REG_RETURN_FLOAT(op2RF / op3F)
             DISPATCH
 
@@ -2679,7 +2679,7 @@ START_OF_INSTRUCTIONS
  *  -----------------------------------------------------------------------------------
  */
         START_INSTRUCTION(FMULT_REG_REG_FLOAT) CALC_DISPATCH(3)
-            DEBUG("TRACE - FMULT R%d,R%d,%g\n", (int)REG_IDX(1), (int)REG_IDX(2), op3F);
+            DEBUG("TRACE - FMULT R%d,R%d,%.15g\n", (int)REG_IDX(1), (int)REG_IDX(2), op3F);
             REG_RETURN_FLOAT(op2RF * op3F)
             DISPATCH
 
@@ -2688,7 +2688,7 @@ START_OF_INSTRUCTIONS
  *  -----------------------------------------------------------------------------------
  */
         START_INSTRUCTION(FSUB_REG_FLOAT_REG) CALC_DISPATCH(3)
-        DEBUG("TRACE - FSUB R%d,%g,R%d\n", (int)REG_IDX(1), op2F, (int)REG_IDX(3));
+        DEBUG("TRACE - FSUB R%d,%.15g,R%d\n", (int)REG_IDX(1), op2F, (int)REG_IDX(3));
             REG_RETURN_FLOAT(op2F - op3RF)
             DISPATCH
 
@@ -2697,7 +2697,7 @@ START_OF_INSTRUCTIONS
  *  -----------------------------------------------------------------------------------
  */
         START_INSTRUCTION(FDIV_REG_FLOAT_REG) CALC_DISPATCH(3)
-        DEBUG("TRACE - FDIV R%d,%g,R%d\n", (int)REG_IDX(1), op2F, (int)REG_IDX(3));
+        DEBUG("TRACE - FDIV R%d,%.15g,R%d\n", (int)REG_IDX(1), op2F, (int)REG_IDX(3));
             REG_RETURN_FLOAT(op2F / op3RF)
             DISPATCH
 /* ------------------------------------------------------------------------------------
@@ -3552,7 +3552,7 @@ START_OF_INSTRUCTIONS
  *  -----------------------------------------------------------------------------------
  */
             START_INSTRUCTION(LOADSETTP_REG_FLOAT_INT) CALC_DISPATCH(3)
-            DEBUG("TRACE - LOADSETTP R%d %g %d\n", (int)REG_IDX(1), op2F,(int) op3I);
+            DEBUG("TRACE - LOADSETTP R%d %.15g %d\n", (int)REG_IDX(1), op2F,(int) op3I);
             op1R->float_value = op2F;
             op1R->status.all_type_flags = op3I;
             DISPATCH

--- a/interpreter/rxvmintp.c
+++ b/interpreter/rxvmintp.c
@@ -812,19 +812,19 @@ START_OF_INSTRUCTIONS
             /* String Say - Deprecated */
             /* START_INSTRUCTION(SSAY_REG) CALC_DISPATCH(1) */
             /*     DEBUG("TRACE - SSAY (DEPRICATED) R%lu\n", REG_IDX(1)); */
-            /*     printf("%.*s", (int) op1R->string_length, op1R->string_value); */
+            /*     mprintf("%.*s", (int) op1R->string_length, op1R->string_value); */
             /*     DISPATCH */
 
             /* Say - Print string value of register as a line */
         START_INSTRUCTION(SAY_REG) CALC_DISPATCH(1)
             DEBUG("TRACE - SAY R%lu\n", REG_IDX(1));
-            printf("%.*s\n", (int) op1R->string_length, op1R->string_value);
+            mprintf("%.*s\n", (int) op1R->string_length, op1R->string_value);
             DISPATCH
 
         START_INSTRUCTION(SAY_STRING) CALC_DISPATCH(1)
             DEBUG("TRACE - SAY \"%.*s\"\n",
                   (int) op1S->string_len, op1S->string);
-            printf("%.*s\n", (int) op1S->string_len, op1S->string);
+            mprintf("%.*s\n", (int) op1S->string_len, op1S->string);
             DISPATCH
 
             /* ------------------------------------------------------------------------------------
@@ -834,7 +834,7 @@ START_OF_INSTRUCTIONS
         START_INSTRUCTION(SAYX_STRING) CALC_DISPATCH(1)
             DEBUG("TRACE - SAYX \"%.*s\"\n",
                   (int) op1S->string_len, op1S->string);
-            printf("%.*s", (int) op1S->string_len, op1S->string);
+            mprintf("%.*s", (int) op1S->string_len, op1S->string);
             DISPATCH
 
         START_INSTRUCTION(SCONCAT_REG_REG_REG) CALC_DISPATCH(3)
@@ -2577,9 +2577,9 @@ START_OF_INSTRUCTIONS
         START_INSTRUCTION(SAY_INT) CALC_DISPATCH(1)
             DEBUG("TRACE - SAY %d\n", (int)op1I);
 #ifdef __32BIT__
-            printf("%ld\n", op1I);
+            mprintf("%ld\n", op1I);
 #else
-            printf("%lld\n", op1I);
+            mprintf("%lld\n", op1I);
 #endif
             DISPATCH
 
@@ -2589,7 +2589,7 @@ START_OF_INSTRUCTIONS
  */
         START_INSTRUCTION(SAY_CHAR) CALC_DISPATCH(1)
             DEBUG("TRACE - SAY \'%c\'\n", (pc + (1))->cconst);
-            printf("%c\n", (pc + (1))->cconst);
+            mprintf("%c\n", (pc + (1))->cconst);
             DISPATCH
 
 /* ------------------------------------------------------------------------------------
@@ -2598,7 +2598,7 @@ START_OF_INSTRUCTIONS
  */
         START_INSTRUCTION(SAY_FLOAT) CALC_DISPATCH(1)
             DEBUG("TRACE - SAY %g\n", op1F);
-            printf("%g\n", op1F);
+            mprintf("%g\n", op1F);
             DISPATCH
 
 /* ------------------------------------------------------------------------------------
@@ -4282,7 +4282,7 @@ START_INSTRUCTION(OPENDLL_REG_REG_REG) CALC_DISPATCH(3)
     }
 
 #ifndef NDEBUG
-    if (context->debug_mode) printf("Interpreter Finished\n");
+    if (context->debug_mode) mprintf("Interpreter Finished\n");
 #endif
 
     return rc;

--- a/interpreter/rxvmintp.h
+++ b/interpreter/rxvmintp.h
@@ -5,7 +5,7 @@
 #include "rxbin.h"
 #include "rxpa.h"
 
-#define rxversion "crexx-f0051"
+#define rxversion "crexx-f0052"
 
 #define SMALLEST_STRING_BUFFER_LENGTH 32
 
@@ -308,5 +308,8 @@ void arr2redr(value* redirect_reg, value* string_reg);
 /* Create a null redirect pipe */
 /* In general, he redirect_reg MUST then be used in shellspawn() to cleanup/free memory */
 void nullredr(value* redirect_reg);
+
+/* EXIT Function Support */
+void mprintf(const char* format, ...); /* printf replacement - prints to the say exit function (or stdout) */
 
 #endif //CREXX_RXVMINTP_H

--- a/interpreter/rxvmload.c
+++ b/interpreter/rxvmload.c
@@ -317,6 +317,10 @@ int rxldmod(rxvm_context *context, char *file_name) {
         rxpa_functions.setfloat = rxpa_setfloat;
         rxpa_functions.getfloat = rxpa_getfloat;
 
+        // Exit Function Management
+        rxpa_functions.setsayexit = rxpa_setsayexit;
+        rxpa_functions.resetsayexit = rxpa_resetsayexit;
+
         // Load the plugin - and run the plugin initialization function
         // Create the filename by appending ".rxplugin" to the file name
         char *full_file_name = malloc(strlen(file_name) + strlen(".rxplugin") + 1);
@@ -545,6 +549,10 @@ int rxldmodp(rxvm_context *context) {
     rxpa_functions.getint = rxpa_getint;
     rxpa_functions.setfloat = rxpa_setfloat;
     rxpa_functions.getfloat = rxpa_getfloat;
+
+    // Exit Function Management
+    rxpa_functions.setsayexit = rxpa_setsayexit;
+    rxpa_functions.resetsayexit = rxpa_resetsayexit;
 
     // Create rxpa_context and module
     char* dummy_file_name = "statically_linked_plugins";

--- a/interpreter/rxvmvars.h
+++ b/interpreter/rxvmvars.h
@@ -851,7 +851,7 @@ RX_INLINE void string_from_int(value *v) {
 /* Calculate the string value */
 RX_INLINE void string_from_float(value *v) {
     prep_string_buffer(v, SMALLEST_STRING_BUFFER_LENGTH); // Large enough for a float
-    v->string_length = snprintf(v->string_value,SMALLEST_STRING_BUFFER_LENGTH,"%g",v->float_value);
+    v->string_length = snprintf(v->string_value,SMALLEST_STRING_BUFFER_LENGTH,"%.15g",v->float_value);
     v->string_pos = 0;
 #ifndef NUTF8
     v->string_char_pos = 0;

--- a/lib/rxfns/native/des/CMakeLists.txt
+++ b/lib/rxfns/native/des/CMakeLists.txt
@@ -15,8 +15,7 @@ add_executable(desbase_test desbase_test.c desbase.c desbase.h)
 # Rexx Test
 add_custom_target(DESRexxTest ALL
         BYPRODUCTS RxDesTst.rxbin
-        COMMAND ${CMAKE_BINARY_DIR}/compiler/rxc -i \"${CMAKE_BINARY_DIR}/lib/rxfns\;${CMAKE_CURRENT_BINARY_DIR}\" -o RxDesTst ${CMAKE_CURRENT_SOURCE_DIR}/RxDesTst
-        COMMAND ${CMAKE_BINARY_DIR}/assembler/rxas RxDesTst
+        COMMAND ${CMAKE_BINARY_DIR}/compiler/rxc -i \"${CMAKE_BINARY_DIR}/lib/rxfns\;${CMAKE_CURRENT_BINARY_DIR}\" -o RxDesTst ${CMAKE_CURRENT_SOURCE_DIR}/RxDesTst && ${CMAKE_BINARY_DIR}/assembler/rxas RxDesTst
         DEPENDS rxas rxc library des RxDesTst.rexx
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
@@ -24,8 +23,7 @@ add_custom_target(DESRexxTest ALL
 # Rexx Error Test
 add_custom_target(DESRexxInvalidTest ALL
         BYPRODUCTS RxDesTstInvalid.rxbin
-        COMMAND ${CMAKE_BINARY_DIR}/compiler/rxc -i \"${CMAKE_BINARY_DIR}/lib/rxfns\;${CMAKE_CURRENT_BINARY_DIR}\" -o RxDesTstInvalid ${CMAKE_CURRENT_SOURCE_DIR}/RxDesTstInvalid
-        COMMAND ${CMAKE_BINARY_DIR}/assembler/rxas RxDesTstInvalid
+        COMMAND ${CMAKE_BINARY_DIR}/compiler/rxc -i \"${CMAKE_BINARY_DIR}/lib/rxfns\;${CMAKE_CURRENT_BINARY_DIR}\" -o RxDesTstInvalid ${CMAKE_CURRENT_SOURCE_DIR}/RxDesTstInvalid && ${CMAKE_BINARY_DIR}/assembler/rxas RxDesTstInvalid
         DEPENDS rxas rxc library des RxDesTstInvalid.rexx
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )

--- a/platform/platform.h
+++ b/platform/platform.h
@@ -39,11 +39,19 @@
 #include "cms.h"
 #endif
 
+#ifndef RXINTEGER_T
+#define RXINTEGER_T
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L /* C99 */
+#include <stdint.h>
+typedef intmax_t rxinteger;
+#else
 #ifdef __32BIT__
 typedef long rxinteger;
 #else
 typedef long long rxinteger;
 #endif
+#endif
+#endif //RXINTEGER_T
 
 /*
  * Read a file into a returned buffer

--- a/tests/levelb/CMakeLists.txt
+++ b/tests/levelb/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.00)
+cmake_minimum_required(VERSION 3.5)
 
 project(tests C)
 

--- a/tests/rxpa/CMakeLists.txt
+++ b/tests/rxpa/CMakeLists.txt
@@ -37,6 +37,7 @@ add_executable(testvm
         ${CMAKE_SOURCE_DIR}/utf8/utf.h
         ${CMAKE_SOURCE_DIR}/machine/rxbin.h
         ${CMAKE_SOURCE_DIR}/interpreter/rxspawn.c
+        ${CMAKE_SOURCE_DIR}/interpreter/exitfunc.c
         ${CMAKE_SOURCE_DIR}/interpreter/rxpafuncs.c)
 # Set the performance properties
 set_property(TARGET testvm PROPERTY INTERPROCEDURAL_OPTIMIZATION_RELEASE TRUE)
@@ -58,8 +59,7 @@ target_include_directories(testvm PRIVATE
 
 # Build Dynamic Test Rexx
 add_custom_command(
-        COMMAND ${CMAKE_BINARY_DIR}/compiler/rxc -i \"${CMAKE_BINARY_DIR}/lib/rxfns\;${CMAKE_CURRENT_BINARY_DIR}\" -o rxpa_dynlink_test \"${CMAKE_CURRENT_SOURCE_DIR}/rxpa_dynlink\"
-        COMMAND ${CMAKE_BINARY_DIR}/assembler/rxas rxpa_dynlink_test
+        COMMAND ${CMAKE_BINARY_DIR}/compiler/rxc -i \"${CMAKE_BINARY_DIR}/lib/rxfns\;${CMAKE_CURRENT_BINARY_DIR}\" -o rxpa_dynlink_test \"${CMAKE_CURRENT_SOURCE_DIR}/rxpa_dynlink\" && ${CMAKE_BINARY_DIR}/assembler/rxas rxpa_dynlink_test
         DEPENDS rxas rxc library _rxpa_dynlink ${CMAKE_CURRENT_SOURCE_DIR}/rxpa_dynlink.rexx
         OUTPUT rxpa_dynlink_test.rxbin
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
@@ -70,8 +70,7 @@ add_custom_target(rxpa_dynlink_test ALL
 
 # Build Static Test Rexx
 add_custom_command(
-        COMMAND rxc_staticlink -i \"${CMAKE_BINARY_DIR}/lib/rxfns\;${CMAKE_CURRENT_BINARY_DIR}\" -o rxpa_staticlink_test \"${CMAKE_CURRENT_SOURCE_DIR}/rxpa_staticlink\"
-        COMMAND ${CMAKE_BINARY_DIR}/assembler/rxas rxpa_staticlink_test
+        COMMAND rxc_staticlink -i \"${CMAKE_BINARY_DIR}/lib/rxfns\;${CMAKE_CURRENT_BINARY_DIR}\" -o rxpa_staticlink_test \"${CMAKE_CURRENT_SOURCE_DIR}/rxpa_staticlink\" && ${CMAKE_BINARY_DIR}/assembler/rxas rxpa_staticlink_test
         DEPENDS rxas rxc_staticlink library ${CMAKE_CURRENT_SOURCE_DIR}/rxpa_staticlink.rexx
         OUTPUT rxpa_staticlink_test.rxbin
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
@@ -123,6 +122,7 @@ add_executable(funcvm
         ${CMAKE_SOURCE_DIR}/utf8/utf.h
         ${CMAKE_SOURCE_DIR}/machine/rxbin.h
         ${CMAKE_SOURCE_DIR}/interpreter/rxspawn.c
+        ${CMAKE_SOURCE_DIR}/interpreter/exitfunc.c
         ${CMAKE_SOURCE_DIR}/interpreter/rxpafuncs.c)
 # Set the performance properties
 set_property(TARGET funcvm PROPERTY INTERPROCEDURAL_OPTIMIZATION_RELEASE TRUE)
@@ -163,8 +163,7 @@ foreach(idx RANGE ${len})
     list(GET OUTPUTS ${idx} _expected_output)
 
     add_custom_command(
-            COMMAND ${CMAKE_BINARY_DIR}/compiler/rxc -i \"${CMAKE_BINARY_DIR}/lib/rxfns\;${CMAKE_CURRENT_BINARY_DIR}\" -o ${_rexxtest}_test ${CMAKE_CURRENT_SOURCE_DIR}/${_rexxtest}
-            COMMAND ${CMAKE_BINARY_DIR}/assembler/rxas ${_rexxtest}_test
+            COMMAND ${CMAKE_BINARY_DIR}/compiler/rxc -i \"${CMAKE_BINARY_DIR}/lib/rxfns\;${CMAKE_CURRENT_BINARY_DIR}\" -o ${_rexxtest}_test ${CMAKE_CURRENT_SOURCE_DIR}/${_rexxtest} && ${CMAKE_BINARY_DIR}/assembler/rxas ${_rexxtest}_test
             DEPENDS rxas rxc library _testfuncs_dynamic ${CMAKE_CURRENT_SOURCE_DIR}/${_rexxtest}.rexx
             OUTPUT ${_rexxtest}_test.rxbin
             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}

--- a/tests/rxpa/rxpa_functests.c
+++ b/tests/rxpa/rxpa_functests.c
@@ -60,7 +60,7 @@ PROCEDURE(add_integers)
     int result;
 
     /* This should never happen as the compiler will have spotted this error */
-    /* However best practice is to check this as versions may have changed   */
+    /* However, the best practice is to check this as versions may have changed   */
     if( NUM_ARGS != 2) RETURNSIGNAL(SIGNAL_INVALID_ARGUMENTS, "2 arguments expected")
 
     // Add the integers
@@ -117,7 +117,7 @@ PROCEDURE(add_floats_ref)
     double result;
 
     /* This should never happen as the compiler will have spotted this error */
-    /* However best practice is to check this as versions may have changed   */
+    /* However, the best practice is to check this as versions may have changed   */
     if( NUM_ARGS != 3) RETURNSIGNAL(SIGNAL_INVALID_ARGUMENTS, "3 arguments expected")
 
     // Add the floats


### PR DESCRIPTION
```
F0052 - Fixes and enhancements
        RXPA - Added an "exit" to trap say instruction output
        Compiler - Fix Register swap back after a function call with global register
        Interpreter - Printing floats, changed max precision to 15 from 6 digits
        Compiler - Fix segfault with a missing argument before an ellipsis
        Compiler - Fix segfault when exposing an unknown variable
```