### PR TITLE
eliminate sysinfo plugin by moving getLoadPath to system plugin; have crexx and os class use system

### DIFF
--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -5,10 +5,10 @@ project(driver C)
 set(CMAKE_C_STANDARD 90)
 
 add_custom_command(
-        COMMAND $<TARGET_FILE:rxc> -x -i "\"${CMAKE_BINARY_DIR}/bin;${CMAKE_BINARY_DIR}/lib/plugins/sysinfo\"" -o crexx ${CMAKE_CURRENT_SOURCE_DIR}/crexx
+        COMMAND $<TARGET_FILE:rxc> -x -i "\"${CMAKE_BINARY_DIR}/bin;${CMAKE_BINARY_DIR}/lib/plugins/system\"" -o crexx ${CMAKE_CURRENT_SOURCE_DIR}/crexx
         COMMAND $<TARGET_FILE:rxas> crexx
         COMMAND $<TARGET_FILE:rxcpack> crexx ${CMAKE_BINARY_DIR}/bin/library
-        DEPENDS rxas rxc crexx.rexx library rxcpack rxpa _sysinfo compiler_exit_bin
+        DEPENDS rxas rxc crexx.rexx library rxcpack rxpa _system compiler_exit_bin
         OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/crexx.c
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
         COMMENT "cREXX compile, assemble and package crexx ..."
@@ -16,8 +16,8 @@ add_custom_command(
 
 add_executable(crexx ${CMAKE_CURRENT_BINARY_DIR}/crexx.c)
 
-configure_linker_for_static_lib_rel(crexx sysinfo _sysinfo)
+configure_linker_for_static_lib_rel(crexx system _system)
 
 target_link_libraries(crexx rxvml rxpashim)
 
-add_dependencies(crexx rxvml rxpa avl_tree platform _sysinfo)
+add_dependencies(crexx rxvml rxpa avl_tree platform _system)

--- a/lib/classlib/os.rexx
+++ b/lib/classlib/os.rexx
@@ -25,8 +25,16 @@ os: class
     
     /** 
     * method user returns the logged on userid
-    * @return .string userid
+    * @return .string userid tsk
     */
   user: method = .string
     return userid()  
+
+    /** 
+    * method getLoadPath returns the path from which
+    * the program is run
+    * @return .string userid tsk
+    */
+  loadpath: method = .string
+    return getLoadPath()
     

--- a/lib/plugins/system/CMakeLists.txt
+++ b/lib/plugins/system/CMakeLists.txt
@@ -26,4 +26,5 @@ target_include_directories(_system_static PRIVATE
     ${CMAKE_SOURCE_DIR}/include
     ${CMAKE_SOURCE_DIR}/lib/include
     ${CMAKE_SOURCE_DIR}/rxpa
-)
+    )
+  

--- a/lib/plugins/system/system.c
+++ b/lib/plugins/system/system.c
@@ -5,6 +5,8 @@
 #include <stdlib.h>
 #include <limits.h>
 #if defined(__APPLE__)
+ #include <mach-o/dyld.h>
+ #include <libgen.h>
  #include <pwd.h>
  #include <sys/stat.h>
  #include <sys/time.h>
@@ -112,6 +114,61 @@ PROCEDURE(getdir) {
     }
 ENDPROC
 }
+/* -------------------------------------------------------------------------------------
+ * Get current load path
+ * -------------------------------------------------------------------------------------
+ */
+PROCEDURE(getLoadPath) {
+    char path[4096];
+    char *dir = NULL;
+
+#if defined(_WIN32)
+    if (GetModuleFileNameA(NULL, path, sizeof(path)) == 0) {
+      RETURNSIGNAL(SIGNAL_FAILURE, "Unable to get current load path")
+    }
+    char *last_backslash = strrchr(path, '\\');
+    if (last_backslash)
+        *last_backslash = '\0';
+    dir = _strdup(path);
+
+#elif defined(__APPLE__)
+    uint32_t size = sizeof(path);
+     if (_NSGetExecutablePath(path, &size) != 0)
+       RETURNSIGNAL(SIGNAL_FAILURE, "Unable to get current load path")
+
+    char resolved[PATH_MAX];
+    if (realpath(path, resolved) == NULL)
+      RETURNSIGNAL(SIGNAL_FAILURE, "Unable to get current load path")
+
+    // dirname may modify its argument, so copy it
+    char *dirbuf = strdup(resolved);
+    if (dirbuf) {
+        dir = strdup(dirname(dirbuf));
+        free(dirbuf);
+    }
+
+#elif defined(__linux__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+    ssize_t len = readlink("/proc/self/exe", path, sizeof(path) - 1);
+    if (len != -1) {
+        path[len] = '\0';
+        char *dirbuf = strdup(path);
+        if (dirbuf) {
+            dir = strdup(dirname(dirbuf));
+            free(dirbuf);
+        }
+    }
+#endif
+    if (dir) {
+        SETSTRING(RETURN, dir);
+        free(dir);
+    } else {
+        SETSTRING(RETURN, "");
+    }
+    PROCRETURN
+ENDPROC
+}
+
+
 /* -------------------------------------------------------------------------------------
  * Set new current working directory
  * -------------------------------------------------------------------------------------
@@ -1244,6 +1301,7 @@ LOADFUNCS
 //      C Function, REXX namespace & name, Option, Return Type, Arguments
     ADDPROC(getEnv,      "system.getenv",      "b",    ".string", "input=.string");
     ADDPROC(getdir,      "system.getdir",      "b",    ".string", "");
+    ADDPROC(getLoadPath, "system.getloadpath", "b",    ".string", "");
     ADDPROC(setdir,      "system.setdir",      "b",    ".int",    "arg0=.string");
     ADDPROC(testdir,     "system.testdir",     "b",    ".int",    "arg0=.string");
     ADDPROC(createdir,   "system.createdir",   "b",    ".int",    "arg0=.string");


### PR DESCRIPTION
eliminate sysinfo plugin by moving getLoadPath to system plugin; have crexx and os class use system. sysinfo had only one call that was not in system.c; we can decommission sysinfo.c after this.