### PR TITLE
Fix comprehensive instrumented VM preparation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -455,7 +455,6 @@ if(BUILD_TESTING)
                 program_generation_control-rxbvml
                 program_generation_control-rxtvml
                 program_generation_control-rxvml
-                rxbvm_instrumented
                 rxc_classdecl_static
                 rxc_staticlink
                 signal_tester

--- a/interpreter/CMakeLists.txt
+++ b/interpreter/CMakeLists.txt
@@ -396,8 +396,10 @@ if(BUILD_TESTING)
 
     if(CREXX_DEFAULT_VM_TARGET STREQUAL "rxtvm")
         add_executable(rxvm_instrumented ALIAS rxtvm_instrumented)
+        set(_crexx_default_instrumented_vm_target rxtvm_instrumented)
     else()
         add_executable(rxvm_instrumented ALIAS rxbvm_instrumented)
+        set(_crexx_default_instrumented_vm_target rxbvm_instrumented)
     endif()
 endif()
 
@@ -1157,6 +1159,12 @@ if(BUILD_TESTING)
             EXPECTED_FAILURE_DESCRIPTION "instrumented threaded VM uncaught SIGNAL OTHER"
             REQUIRED_OUTPUT_REGEX ${_instrumented_signal_required_output}
             TEST_LABELS interpreter instrumentation signal)
+    crexx_register_test_prep_targets(
+            TESTS rxvminstrumentedsignaltests
+            TARGETS ${_crexx_default_instrumented_vm_target} run_tests_signals)
+    crexx_register_test_prep_targets(
+            TESTS rxbvminstrumentedsignaltests
+            TARGETS rxbvm_instrumented run_tests_signals)
 endif()
 
 # Instruction Sanity Tests - fallback panic location and source reporting
@@ -1212,6 +1220,12 @@ if(BUILD_TESTING)
     set_tests_properties(rxvminstrumentedbreakpointtests rxbvminstrumentedbreakpointtests PROPERTIES
             PASS_REGULAR_EXPRESSION "VM instrumentation: PASS .*returns=[1-9][0-9]* interrupts=[1-9][0-9]*/[1-9][0-9]*/[1-9][0-9]*/0"
             LABELS "interpreter;instrumentation;breakpoint")
+    crexx_register_test_prep_targets(
+            TESTS rxvminstrumentedbreakpointtests
+            TARGETS ${_crexx_default_instrumented_vm_target} run_tests_breakpoint_address)
+    crexx_register_test_prep_targets(
+            TESTS rxbvminstrumentedbreakpointtests
+            TARGETS rxbvm_instrumented run_tests_breakpoint_address)
 endif()
 
 # Instruction Sanity Tests - register flag partitioning


### PR DESCRIPTION
## Summary

- make each instrumented VM test declare its concrete runner dependency
- make the signal and breakpoint tests declare their generated bytecode fixtures
- remove the platform-specific broad rxbvm preparation dependency

## Root cause

On GNU platforms the default instrumented VM alias resolves to rxtvm_instrumented, while comprehensive preparation built only rxbvm_instrumented. Linux and Windows therefore entered CTest without the executable selected by the test command. AppleClang selects rxbvm_instrumented, which is why both macOS jobs passed.

## Validation

- local Debug: all four affected signal and breakpoint tests pass concurrently
- exact-SHA hosted comprehensive matrix: all four platforms green
  - Linux x64: 17m0s, including install/package qualification
  - Windows x64: 20m53s
  - macOS arm64: 12m30s
  - macOS x86_64: 32m14s
- full run: https://github.com/adesutherland/CREXX/actions/runs/33540408705
- synchronization with master changed history only; the Git tree hash remained ce087278c8a23cd1cab83892736f2a25990f3176